### PR TITLE
modifies Preview Changes button within WP dashboard to properly point to client app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,6 +71,7 @@ client/build
 # ignore WP 
 api/wp-admin
 api/wp-content/index.php
+api/wp-content/debug.log
 api/wp-includes
 api/.htaccess
 api/index.php

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ After you're up and running, we need to navigate to `http://localhost:8080/wp-ad
 2. Activate plugins ACF PRO, ACF to REST API, and WP REST API Cache
 3. Import boilerplate ACF custom fields by navigating to `Custom Fields -> Tools`, and uploading `api/acf/acf-meta.data.json`.  This will add meta fields to each Page and Post by default, avoiding the need for Yoast SEO or similar plugins.  Extend and add to other post types as you need.
 4. Update your Site Address within `Settings -> General` to your SSR app (default: http://localhost:1337)
-5. Change Permalinks to the 'Post Name' option
+5. Change Permalinks to the 'Custom Structure' option and enter `/post/%postname%/`
 
 *Note:* It's important that the Permalinks update is performed last in the order above.
 

--- a/api/wp-content/themes/rest-api/functions.php
+++ b/api/wp-content/themes/rest-api/functions.php
@@ -1,5 +1,8 @@
 <?php
 
+// Helper utilities
+require_once('inc/utilities.php');
+
 // Enable CORS from client
 require_once('inc/cors.php');
 

--- a/api/wp-content/themes/rest-api/functions.php
+++ b/api/wp-content/themes/rest-api/functions.php
@@ -1,5 +1,8 @@
 <?php
 
+// Enable CORS from client
+require_once('inc/cors.php');
+
 // Register menu endpoints
 require_once('inc/menus.php');
 

--- a/api/wp-content/themes/rest-api/inc/cors.php
+++ b/api/wp-content/themes/rest-api/inc/cors.php
@@ -12,3 +12,5 @@ add_action( 'rest_api_init', function() {
 		return $value;
 	});
 }, 15 );
+
+?>

--- a/api/wp-content/themes/rest-api/inc/cors.php
+++ b/api/wp-content/themes/rest-api/inc/cors.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * Allow GET requests from * origin
+ * Thanks to https://joshpress.net/access-control-headers-for-the-wordpress-rest-api/
+ */
+add_action( 'rest_api_init', function() {
+	remove_filter( 'rest_pre_serve_request', 'rest_send_cors_headers' );
+	add_filter( 'rest_pre_serve_request', function( $value ) {
+		header( 'Access-Control-Allow-Origin: ' . get_home_url() );
+		header( 'Access-Control-Allow-Methods: GET' );
+		header( 'Access-Control-Allow-Credentials: true' );
+		return $value;
+	});
+}, 15 );

--- a/api/wp-content/themes/rest-api/inc/custom-post-types.php
+++ b/api/wp-content/themes/rest-api/inc/custom-post-types.php
@@ -4,7 +4,6 @@ register_post_type( 'static-content', array(
 	'public' => true,
 	'has_archive' => true,
 	'menu_position' => 22, // places menu item directly below Pages
-
 	'labels' => array(
 		'name' => __( 'Static Content' ),
 		'singular_name' => __( 'Static Content' ),
@@ -17,8 +16,10 @@ register_post_type( 'static-content', array(
 		'view_item' => __( 'View Static Content' ),
 		'search_items' => __( 'Search Static Content' ),
 		'not_found' => __( 'No Static Content found in Trash' ),
-		'parent' => __( 'Parent Static Content' ),
-		'show_in_rest' => true,
+		'parent' => __( 'Parent Static Content' )
+	),
+	'rewrite'    => array (
+	    'with_front' => false
 	),
 	'supports' => array( 'title', 'editor', 'thumbnail' ),
 	'show_in_rest' => true

--- a/api/wp-content/themes/rest-api/inc/routes.php
+++ b/api/wp-content/themes/rest-api/inc/routes.php
@@ -1,7 +1,11 @@
 <?php
 
-function get_page_routes() {
-	# Change 'menu' to your own navigation slug.
+////////////////////////////////////////////////////////////////
+// Creates route for succinctly sending a list 
+// of all published pages including templates used
+////////////////////////////////////////////////////////////////
+
+function react_wp_rest_get_page_routes() {
 	$pages = get_pages();
 	$names = [];
 
@@ -29,10 +33,51 @@ function get_page_routes() {
 	return $names;
 }
 
+////////////////////////////////////////////////////////////////
+// Create route for previewing post data of any post type
+////////////////////////////////////////////////////////////////
+
+function react_wp_rest_get_preview_data(WP_REST_Request $request) {
+
+	$post = get_page_by_path($request->get_param('slug'));
+	$post_id = $post->ID;
+
+	// Revisions are drafts so here we remove the default 'publish' status
+	remove_action('pre_get_posts', 'set_default_status_to_publish');
+	
+	if ( $revisions = wp_get_post_revisions( $post_id, array( 'check_enabled' => false ) )) {
+		$last_revision = reset($revisions);
+		$rev_post = wp_get_post_revision($last_revision->ID);
+		$controller = new WP_REST_Posts_Controller('post');
+		$data = $controller->prepare_item_for_response( $rev_post, $request );
+	} elseif ( $post = get_post( $post_id ) ) { 
+		// There are no revisions, just return the saved parent post
+		$controller = new WP_REST_Posts_Controller('post');
+		$data = $controller->prepare_item_for_response( $post, $request );
+	} else {
+		return new WP_Error( 'rest_get_post_preview', 'Post ' . $post_id . ' does not exist',
+			array( 'status' => 404 ) );
+	}
+	$response = $controller->prepare_response_for_collection( $data );
+	return new WP_REST_Response($response);
+}
+
+////////////////////////////////////////////////////////////////
+// Register routes
+////////////////////////////////////////////////////////////////
+
 add_action( 'rest_api_init', function () {
-	register_rest_route( 'pages', '/list', array(
+	register_rest_route( 'react-wp-rest', '/pages/list', array(
 		'methods' => 'GET',
-		'callback' => 'get_page_routes',
+		'callback' => 'react_wp_rest_get_page_routes',
+	) );
+
+	register_rest_route( 'react-wp-rest', '/preview', array(
+		'methods' => 'GET',
+		'callback' => 'react_wp_rest_get_preview_data',
+		'permission_callback' => function() {
+			return current_user_can( 'edit_posts' );
+		}
 	) );
 } );
 

--- a/api/wp-content/themes/rest-api/inc/routes.php
+++ b/api/wp-content/themes/rest-api/inc/routes.php
@@ -23,7 +23,7 @@ function react_wp_rest_get_page_routes() {
 				'path' => get_page_uri($page->ID),
 				'slug' => $page->post_name,
 				'template' => $template,
-				'type' => 'pages'
+				'type' => 'page'
 			);
 
 			array_push($names, $name);
@@ -39,7 +39,8 @@ function react_wp_rest_get_page_routes() {
 
 function react_wp_rest_get_preview_data(WP_REST_Request $request) {
 
-	$post = get_page_by_path($request->get_param('slug'));
+	$post = get_post_by_slug($request->get_param('slug'));
+
 	$post_id = $post->ID;
 
 	// Revisions are drafts so here we remove the default 'publish' status

--- a/api/wp-content/themes/rest-api/inc/theme-setup.php
+++ b/api/wp-content/themes/rest-api/inc/theme-setup.php
@@ -56,11 +56,21 @@ add_action( 'save_post', function( $post_id ) {
 });
 
 // Add nonce to WP preview link
-function set_headless_preview_link( $link ) {
-	return get_home_url() . '/'
+function set_headless_preview_link( $link, $post ) {
+
+	$path = str_replace(home_url(), '', get_permalink($post));
+
+	// If post type is page, set type equal to blank string
+	$type = $post->post_type === 'page'
+		? ''
+		: '/' . $post->post_type;
+
+	return get_home_url()
+		. $type
+		. $path
 		. '?preview=true&_wpnonce='
 		. wp_create_nonce( 'wp_rest' );
 }
-add_filter( 'preview_post_link', 'set_headless_preview_link' );
+add_filter( 'preview_post_link', 'set_headless_preview_link', 10, 2 );
 
 ?>

--- a/api/wp-content/themes/rest-api/inc/theme-setup.php
+++ b/api/wp-content/themes/rest-api/inc/theme-setup.php
@@ -55,4 +55,12 @@ add_action( 'save_post', function( $post_id ) {
     }
 });
 
+// Add nonce to WP preview link
+function set_headless_preview_link( $link ) {
+	return get_home_url() . '/'
+		. '?preview=true&_wpnonce='
+		. wp_create_nonce( 'wp_rest' );
+}
+add_filter( 'preview_post_link', 'set_headless_preview_link' );
+
 ?>

--- a/api/wp-content/themes/rest-api/inc/theme-setup.php
+++ b/api/wp-content/themes/rest-api/inc/theme-setup.php
@@ -60,13 +60,7 @@ function set_headless_preview_link( $link, $post ) {
 
 	$path = str_replace(home_url(), '', get_permalink($post));
 
-	// If post type is page, set type equal to blank string
-	$type = $post->post_type === 'page'
-		? ''
-		: '/' . $post->post_type;
-
 	return get_home_url()
-		. $type
 		. $path
 		. '?preview=true&_wpnonce='
 		. wp_create_nonce( 'wp_rest' );

--- a/api/wp-content/themes/rest-api/inc/utilities.php
+++ b/api/wp-content/themes/rest-api/inc/utilities.php
@@ -1,0 +1,17 @@
+<?php
+// Gets a post of any type by its slug
+function get_post_by_slug($slug){
+    $posts = get_posts(array(
+            'name' => $slug,
+            'post_type' => 'any',
+            'posts_per_page' => 1,
+            'post_status' => 'publish'
+    ));
+    
+    if (!$posts ) {
+        throw new Exception("NoSuchPostBySpecifiedSlug");
+    }
+
+    return $posts[0];
+}
+?>

--- a/client/middleware/renderer.js
+++ b/client/middleware/renderer.js
@@ -88,7 +88,7 @@ export default (store) => (req, res, next) => {
 				</Provider>
 			</Loadable.Capture>
 		);
-
+		
 		// Prevent memory leak (React Helmet docs)
 		const helmet = Helmet.renderStatic();
 

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -7744,6 +7744,22 @@
         "prepend-http": "1.0.4",
         "query-string": "4.3.4",
         "sort-keys": "1.1.2"
+      },
+      "dependencies": {
+        "query-string": {
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/query-string/-/query-string-4.3.4.tgz",
+          "integrity": "sha1-u7aTucqRXCMlFbIosaArYJBD2+s=",
+          "requires": {
+            "object-assign": "4.1.1",
+            "strict-uri-encode": "1.1.0"
+          }
+        },
+        "strict-uri-encode": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
+          "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM="
+        }
       }
     },
     "npm-run-all": {
@@ -9611,15 +9627,6 @@
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
       "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
     },
-    "query-string": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/query-string/-/query-string-4.3.4.tgz",
-      "integrity": "sha1-u7aTucqRXCMlFbIosaArYJBD2+s=",
-      "requires": {
-        "object-assign": "4.1.1",
-        "strict-uri-encode": "1.1.0"
-      }
-    },
     "querystring": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
@@ -11037,11 +11044,6 @@
         "to-arraybuffer": "1.0.1",
         "xtend": "4.0.1"
       }
-    },
-    "strict-uri-encode": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
-      "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM="
     },
     "string-length": {
       "version": "1.0.1",

--- a/client/package.json
+++ b/client/package.json
@@ -10,6 +10,7 @@
     "ignore-styles": "^5.0.1",
     "node-sass-chokidar": "^1.1.2",
     "npm-run-all": "^4.1.2",
+    "qs": "^6.5.1",
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
     "react-helmet": "^5.2.0",

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -31,10 +31,10 @@ class App extends Component {
 							<LoadTemplate
 							{...props} 
 							template="post"
-							type="posts" />
+							type="post" />
 						}
 						exact
-						path="/posts/:slug"/>,
+						path="/post/:slug"/>,
 
 					routes.map((route, i) => {
 

--- a/client/src/api.js
+++ b/client/src/api.js
@@ -9,7 +9,9 @@ const responseBody = res => res.body;
 
 const requests = {
 	get: url =>
-		superagent.get(`${API_ROOT}${url}`).then( responseBody )
+		superagent.get(`${API_ROOT}${url}`).then( responseBody ),
+	getWithCredentials: url =>
+		superagent.get(`${API_ROOT}${url}`).withCredentials().then( responseBody )
 }
 
 const Menus = {
@@ -20,8 +22,10 @@ const Menus = {
 const Content = {
 	dataBySlug: (type, slug) =>
 		requests.get(`/wp-json/wp/v2/${type}?slug=${slug}`),
+	previewDataBySlug: (type, slug, wpnonce) =>
+		requests.getWithCredentials(`/wp-json/react-wp-rest/preview?type=${type}&slug=${slug}&_wpnonce=${wpnonce}`),
 	pageList: () =>
-		requests.get('/wp-json/pages/list')
+		requests.get('/wp-json/react-wp-rest/pages/list')
 } 
 
 export default {

--- a/client/src/components/LoadTemplate/index.js
+++ b/client/src/components/LoadTemplate/index.js
@@ -46,16 +46,26 @@ class LoadTemplate extends Component {
 	constructor(props) {
 		super(props);
 
-		// Slug will either come from a prop or a URL param from Router
-		// Necessary because some slugs come from URL params
 		this.state = {
 			preview: false,
-			slug: this.props.slug ? this.props.slug : this.props.match.params.slug
+
+			// Slug will either come from a prop or a URL param from Router
+			// Necessary because some slugs come from URL params
+			slug: this.props.slug 
+				? this.props.slug 
+				: this.props.match.params.slug,
+
+			// Default WP REST API expects /pages/ and /posts/ formatting
+			// Custom post types are all singular (sigh)
+			fetchType: this.props.type === 'page' 
+				? 'pages'
+				: this.props.type === 'post' 
+				? 'posts'
+				: this.props.type
 		}
 	}
 
 	componentDidMount() {
-
 		let params = [];
 
 		// No need to run any of this on server sides
@@ -67,17 +77,18 @@ class LoadTemplate extends Component {
 		}
 
 		if (params.preview === 'true' && params['_wpnonce']) {
-			api.Content.previewDataBySlug(this.props.type, this.state.slug, params['_wpnonce']).then(
+			api.Content.previewDataBySlug( this.props.type, this.state.slug, params['_wpnonce']).then(
 				res => {
 					this.setState({ preview: res })
 				},
 				error => {
+					console.warn(error);
 					this.props.history.push('/not-found');
 				}
 			);
 		} else if (!this.props.data[this.state.slug]) {
 			// Load page content from API by slug
-			this.props.load(api.Content.dataBySlug(this.props.type, this.state.slug));
+			this.props.load(api.Content.dataBySlug(this.state.fetchType, this.state.slug));
 		}
 	}
 

--- a/client/src/components/LoadTemplate/index.js
+++ b/client/src/components/LoadTemplate/index.js
@@ -56,29 +56,26 @@ class LoadTemplate extends Component {
 
 	componentDidMount() {
 
+		let params = [];
+
 		// No need to run any of this on server sides
 		if (window) {
-			const params = queryString.parse(
+			params = queryString.parse(
 				window.location.search, 
 				{ ignoreQueryPrefix: true }
 			);
-
-			if (params.preview === 'true' && params['_wpnonce']) {
-
-				api.Content.previewDataBySlug(this.props.type, this.state.slug, params['_wpnonce']).then(
-					res => {
-						this.setState({ preview: res })
-					},
-					error => {
-						// TODO:
-						// Redirect to 403
-						console.warn(error);
-					}
-				);
-			}
 		}
 
-		if (!this.props.data[this.state.slug]) {
+		if (params.preview === 'true' && params['_wpnonce']) {
+			api.Content.previewDataBySlug(this.props.type, this.state.slug, params['_wpnonce']).then(
+				res => {
+					this.setState({ preview: res })
+				},
+				error => {
+					this.props.history.push('/not-found');
+				}
+			);
+		} else if (!this.props.data[this.state.slug]) {
 			// Load page content from API by slug
 			this.props.load(api.Content.dataBySlug(this.props.type, this.state.slug));
 		}

--- a/client/src/components/LoadTemplate/index.js
+++ b/client/src/components/LoadTemplate/index.js
@@ -41,6 +41,11 @@ const mapDispatchToProps = dispatch => ({
 	load: (data) => dispatch({ type: 'LOAD_DATA', payload: data })
 });
 
+const canUseDOM = !!(
+  (typeof window !== 'undefined' &&
+  window.document && window.document.createElement)
+);
+
 class LoadTemplate extends Component {
 
 	constructor(props) {
@@ -65,11 +70,11 @@ class LoadTemplate extends Component {
 		}
 	}
 
-	componentDidMount() {
+	componentWillMount() {
 		let params = [];
 
 		// No need to run any of this on server sides
-		if (window) {
+		if (canUseDOM) {
 			params = queryString.parse(
 				window.location.search, 
 				{ ignoreQueryPrefix: true }


### PR DESCRIPTION
Here, we've modified the 'Preview Changes' button within Wordpress to point to the client-side app and opened a new route to provide revision data.  

We've also modified the LoadTemplate component so that it watches for the **preview** URL parameter.  If it's found, the component will pull data from the newly opened `preview` route instead of the default.